### PR TITLE
feat: adding identation to itens following the SBC template

### DIFF
--- a/UASTeX.cls
+++ b/UASTeX.cls
@@ -684,4 +684,31 @@
   \newpage
   \maketitle
 }
+
+% itens
+\setlength\leftmargini   {1.27cm}
+\setlength\leftmargin    {\leftmargini}
+\setlength\leftmarginii  {\leftmargini}
+\setlength\leftmarginiii {\leftmargini}
+\setlength\leftmarginiv  {\leftmargini}
+\setlength  \labelsep    {.5em}
+\setlength  \labelwidth  {\leftmargini}
+\addtolength\labelwidth  {-\labelsep}
+\def\@listi{\leftmargin\leftmargini
+            \parsep 0\p@ \@plus1\p@ \@minus\p@
+            \topsep 0\p@ \@plus2\p@ \@minus4\p@
+            \itemsep0\p@}
+\let\@listi\@listi
+\@listi
+\def\@listii {\leftmargin\leftmarginii
+              \labelwidth\leftmarginii
+              \advance\labelwidth-\labelsep
+              \topsep    0\p@ \@plus2\p@ \@minus\p@}
+\def\@listiii{\leftmargin\leftmarginiii
+              \labelwidth\leftmarginiii
+              \advance\labelwidth-\labelsep
+              \topsep    0\p@ \@plus\p@\@minus\p@
+              \parsep    \z@
+              \partopsep \p@ \@plus\z@ \@minus\p@}
+			  
 \endinput


### PR DESCRIPTION
## What

Adiciona indentação aos itens: `\begin{enumarate}`,  `\begin{itemize}` e `\begin{description}`.

Além disso, resolve também um bug na bibliografia que deixava as referências coladas.

Exemplo:

Deveria ficar:
  ```
  [Zhu et al. 2019]  Zhu, T., Qu, Z., Xu, H., Zhang ...
  ```

Mas ficava:
  ```
  [Zhu et al. 2019]Zhu, T., Qu, Z., Xu, H., Zhang ...
  ```

## How

Apenas peguei o código do template da SBC que define a formatação dos `itens`.