### PR TITLE
fixing: correcting indentation as specified by the SBC template

### DIFF
--- a/UASTeX.cls
+++ b/UASTeX.cls
@@ -532,6 +532,32 @@
 {\def\@noitemerr
 	{\@latex@warning{Empty `thebibliography' environment}}%
 	\endlist}
+
+% itens - (\begin{enumerate, itemize, description})
+\setlength\leftmargini   {1.27cm}
+\setlength\leftmargin    {\leftmargini}
+\setlength\leftmarginii  {\leftmargini}
+\setlength\leftmarginiii {\leftmargini}
+\setlength\leftmarginiv  {\leftmargini}
+\setlength  \labelsep    {.5em}
+\setlength  \labelwidth  {\leftmargini}
+\addtolength\labelwidth  {-\labelsep}
+\def\@listI{\leftmargin\leftmargini
+            \parsep 0\p@ \@plus1\p@ \@minus\p@
+            \topsep 0\p@ \@plus2\p@ \@minus4\p@
+            \itemsep0\p@}
+\let\@listi\@listI
+\@listi
+\def\@listii {\leftmargin\leftmarginii
+              \labelwidth\leftmarginii
+              \advance\labelwidth-\labelsep
+              \topsep    0\p@ \@plus2\p@ \@minus\p@}
+\def\@listiii{\leftmargin\leftmarginiii
+              \labelwidth\leftmarginiii
+              \advance\labelwidth-\labelsep
+              \topsep    0\p@ \@plus\p@\@minus\p@
+              \parsep    \z@
+              \partopsep \p@ \@plus\z@ \@minus\p@}
  
 \newcommand\newblock{\hskip .11em\@plus.33em\@minus.07em}
 \let\@openbib@code\@empty


### PR DESCRIPTION
## What

Adiciona indentação aos itens: `\begin{enumarate}`,  `\begin{itemize}` e `\begin{description}`.

Além disso, resolve também um bug na bibliografia que deixava as referências coladas.

Exemplo:

Deveria ficar:
  ```
  [Zhu et al. 2019]  Zhu, T., Qu, Z., Xu, H., Zhang ...
  ```

Mas ficava:
  ```
  [Zhu et al. 2019]Zhu, T., Qu, Z., Xu, H., Zhang ...
  ```

## How

Apenas peguei o código do template da SBC que define a formatação dos `itens`.